### PR TITLE
refactor(consumer): extract connection behavior

### DIFF
--- a/lib/consumer/amqp_data_consumer/amqp_connection.ex
+++ b/lib/consumer/amqp_data_consumer/amqp_connection.ex
@@ -1,0 +1,19 @@
+defmodule Mississippi.Consumer.AMQPDataConsumer.AMQPConnection do
+  @moduledoc """
+  A behaviour module to for implementing a DataConsumer AMQP connection.
+  """
+
+  alias AMQP.Channel
+  alias Mississippi.Consumer.AMQPDataConsumer.State
+
+  @doc """
+  The adapter module for the AMQP connection
+  """
+  @callback adapter() :: module()
+
+  @doc """
+  Initializes the AMQP connection.
+  Returns `{:ok, channel}` if it was initialized successfully, or `{:error, reason}` if it was not.
+  """
+  @callback init(state :: State.t()) :: {:ok, Channel.t()} | {:error, reason :: term()}
+end

--- a/lib/consumer/amqp_data_consumer/exrabbitpool_connection.ex
+++ b/lib/consumer/amqp_data_consumer/exrabbitpool_connection.ex
@@ -1,0 +1,49 @@
+defmodule Mississippi.Consumer.AMQPDataConsumer.ExRabbitPoolConnection do
+  @behaviour Mississippi.Consumer.AMQPDataConsumer.AMQPConnection
+
+  alias Mississippi.Consumer.AMQPDataConsumer.State
+
+  require Logger
+
+  @consumer_prefetch_count 300
+
+  def adapter(), do: ExRabbitPool.RabbitMQ
+
+  def init(state) do
+    conn = ExRabbitPool.get_connection_worker(:events_consumer_pool)
+
+    case ExRabbitPool.checkout_channel(conn) do
+      {:ok, channel} ->
+        try_to_setup_consume(channel, conn, state)
+
+      {:error, reason} ->
+        _ =
+          Logger.warning(
+            "Failed to check out channel for consumer on queue #{state.queue_name}: #{inspect(reason)}",
+            tag: "channel_checkout_fail"
+          )
+
+        {:error, reason}
+    end
+  end
+
+  defp try_to_setup_consume(channel, conn, state) do
+    %State{queue_name: queue_name} = state
+
+    with :ok <- adapter().qos(channel, prefetch_count: @consumer_prefetch_count),
+         {:ok, _queue} <- adapter().declare_queue(channel, queue_name, durable: true),
+         {:ok, _consumer_tag} <- adapter().consume(channel, queue_name, self()) do
+      {:ok, channel}
+    else
+      {:error, reason} ->
+        Logger.warning(
+          "Error initializing AMQPDataConsumer on queue #{state.queue_name}: #{inspect(reason)}",
+          tag: "data_consumer_init_err"
+        )
+
+        # Something went wrong, let's put the channel back where it belongs
+        _ = ExRabbitPool.checkin_channel(conn, channel)
+        {:error, reason}
+    end
+  end
+end

--- a/lib/consumer/message_tracker.ex
+++ b/lib/consumer/message_tracker.ex
@@ -11,6 +11,7 @@ defmodule Mississippi.Consumer.MessageTracker do
   alias Mississippi.Consumer.MessageTracker
   alias Mississippi.Consumer.Message
   require Logger
+  use Efx
 
   @doc """
   Provides a reference to the MessageTracker process that will track the set of messages identified by
@@ -18,7 +19,7 @@ defmodule Mississippi.Consumer.MessageTracker do
   """
   @spec get_message_tracker(sharding_key :: term()) ::
           {:ok, pid()} | {:error, :message_tracker_start_fail}
-  def get_message_tracker(sharding_key) do
+  defeffect get_message_tracker(sharding_key) do
     name = {:via, Registry, {Registry.MessageTracker, {:sharding_key, sharding_key}}}
 
     # TODO bring back :offload_start (?)

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,2 +1,2 @@
 Hammox.defmock(MockMessageHandler, for: Mississippi.Consumer.DataUpdater.Handler)
-Hammox.defmock(MockRabbitMQ, for: ExRabbitPool.Clients.Adapter)
+Hammox.defmock(MockAMQPConnection, for: Mississippi.Consumer.AMQPDataConsumer.AMQPConnection)


### PR DESCRIPTION
this allows easily mocking it without needing to add an effects module. 
`MessageTracker.get_message_tracker` still needs to be defined as a `defeffect` though.